### PR TITLE
[SUP-211] Add stripPackageJsonFile function and update file handling

### DIFF
--- a/src/assistant/SuperflexAssistant.ts
+++ b/src/assistant/SuperflexAssistant.ts
@@ -19,7 +19,7 @@ import { SUPPORTED_FILE_EXTENSIONS } from '../common/constants'
 import { jsonToMap, mapToJson } from '../common/utils'
 import { findWorkspaceFiles } from '../scanner'
 import type { Assistant } from './Assistant'
-import { createFilesMapName, validateInputMessage } from './common'
+import { createFilesMapName, stripPackageJsonFile, validateInputMessage } from './common'
 
 const ASSISTENT_NAME = 'superflex'
 const FILES_MAP_VERSION = 1 // Increment the version when we need to reindex all files
@@ -230,6 +230,13 @@ export default class SuperflexAssistant implements Assistant {
     const workers = asyncQ.queue(async (documentPaths: string[]) => {
       const files = documentPaths.map(documentPath => {
         const relativePath = path.relative(this.workspaceDirPath, documentPath)
+        if (relativePath.endsWith('package.json')) {
+          return {
+            relativePath,
+            source: stripPackageJsonFile(documentPath),
+            modifiedTime: fs.statSync(documentPath).mtime.getTime()
+          }
+        }
         return {
           relativePath,
           source: fs.readFileSync(documentPath, 'utf8'),

--- a/src/assistant/common.ts
+++ b/src/assistant/common.ts
@@ -1,7 +1,8 @@
+import * as fs from 'node:fs'
+
 import { FIGMA_SELECTION_URL_REGEX, URL_REGEX } from 'shared/common/constants'
 import type { MessageContent } from 'shared/model'
 import { AppError, AppErrorSlug } from 'shared/model/AppError.model'
-import * as fs from 'node:fs'
 
 // Helper function to create the name of the files map
 export function createFilesMapName(provider: string, version: number): string {

--- a/src/assistant/common.ts
+++ b/src/assistant/common.ts
@@ -1,6 +1,7 @@
 import { FIGMA_SELECTION_URL_REGEX, URL_REGEX } from 'shared/common/constants'
 import type { MessageContent } from 'shared/model'
 import { AppError, AppErrorSlug } from 'shared/model/AppError.model'
+import * as fs from 'node:fs'
 
 // Helper function to create the name of the files map
 export function createFilesMapName(provider: string, version: number): string {
@@ -43,4 +44,30 @@ function containsFigmaSelectionURL(inputString: string): boolean {
 
 function containsURL(inputString: string): boolean {
   return URL_REGEX.test(inputString)
+}
+
+export function stripPackageJsonFile(documentPath: string): string {
+  const fileContent = fs.readFileSync(documentPath, 'utf8')
+
+  try {
+    const packageJson = JSON.parse(fileContent)
+    const filteredPackageJson: Record<string, any> = {}
+
+    if (packageJson.name) {
+      filteredPackageJson.name = packageJson.name
+    }
+    if (packageJson.description) {
+      filteredPackageJson.description = packageJson.description
+    }
+    if (packageJson.dependencies) {
+      filteredPackageJson.dependencies = packageJson.dependencies
+    }
+    if (packageJson.devDependencies) {
+      filteredPackageJson.devDependencies = packageJson.devDependencies
+    }
+
+    return JSON.stringify(filteredPackageJson, null, 2)
+  } catch {
+    return fileContent
+  }
 }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -36,7 +36,23 @@ export const SUPPORTED_FILE_EXTENSIONS = [
   '.ts',
   '.jsx',
   '.tsx',
-  '.vue'
+  '.vue',
+  '.md',
+  '.markdown'
+]
+
+// project json files that are relevant for code generation
+export const RELEVANT_JSON_FILES = [
+  'theme.json',
+  'tailwind.config.json',
+  'menu.json',
+  'forms.json',
+  'components.json',
+  'manifest.json',
+  'package.json',
+  'tsconfig.json',
+  'eslint.json',
+  'prettier.config.json'
 ]
 
 // Binary and non-programming file types to ignore when scanning workspace

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -2,7 +2,10 @@ import fs from 'node:fs'
 import path from 'node:path'
 import fg from 'fast-glob'
 
-import { SUPPORTED_FILE_EXTENSIONS } from '../common/constants'
+import {
+  SUPPORTED_FILE_EXTENSIONS,
+  RELEVANT_JSON_FILES
+} from '../common/constants'
 import { decodeUriAndRemoveFilePrefix } from '../common/utils'
 
 /**
@@ -90,7 +93,10 @@ export async function findWorkspaceFiles(
   ignore?: string[]
 ): Promise<string[]> {
   if (!globPatterns) {
-    globPatterns = SUPPORTED_FILE_EXTENSIONS.map(ext => `**/*${ext}`)
+    globPatterns = [
+      ...SUPPORTED_FILE_EXTENSIONS.map(ext => `**/*${ext}`),
+      ...RELEVANT_JSON_FILES.map(file => `**/${file}`)
+    ]
   }
 
   // Default ignore patterns


### PR DESCRIPTION
- Introduced stripPackageJsonFile function to read and filter package.json content, retaining only relevant fields (name, description, dependencies, devDependencies).
- Updated SuperflexAssistant to utilize stripPackageJsonFile when processing package.json files, enhancing file handling.
- Expanded SUPPORTED_FILE_EXTENSIONS in constants to include .md and .markdown, and added RELEVANT_JSON_FILES for improved file scanning.
