### PR TITLE
[SUP-203] Add business logic file patterns to ignore list in workspace file sca…

### DIFF
--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -108,6 +108,20 @@ export async function findWorkspaceFiles(
     '**/__mocks__/**'
   ]
 
+  // Ignore business logic files
+  const businessLogicIgnore = [
+    '**/services/*',
+    '**/data/*',
+    '**/errors/*',
+    '**/tests/**',
+    '**/migrations/**',
+    '**/middleware/**',
+    '**/validators/**',
+    '**/helpers/**',
+    '**/domain/**',
+    '**/infrastructure/**',
+  ]
+
   // Read .gitignore and .superflexignore
   const gitignorePatterns = readIgnoreFile(
     path.join(workspaceDirPath, '.gitignore')
@@ -121,7 +135,8 @@ export async function findWorkspaceFiles(
     ...(ignore || []),
     ...defaultIgnore,
     ...gitignorePatterns,
-    ...superflexignorePatterns
+    ...superflexignorePatterns,
+    ...businessLogicIgnore
   ]
 
   return findFiles(workspaceDirPath, globPatterns, combinedIgnore)


### PR DESCRIPTION
- Introduced a new set of ignore patterns specifically for business logic files, including services, data, errors, tests, migrations, middleware, validators, helpers, domain, and infrastructure directories.
- Updated the combined ignore patterns in the findWorkspaceFiles function to include these new business logic ignore patterns.